### PR TITLE
Modified line 137 based on output_reports.pl line 1394.

### DIFF
--- a/bin/output_sunburst_json.abund.pl
+++ b/bin/output_sunburst_json.abund.pl
@@ -134,7 +134,12 @@ sub getKids{
     
     
     my $current_count = $terms->{$current}->{count};
-    my $current_count_pct = sprintf("%.2f", $current_count*100/$root_count);
+    
+    # Proposed change. Does this mess with the underlying logic?
+    my $current_count_pct = $root_count != 0 ? sprintf("%.2f", $current_count*100/$root_count) : 0;
+
+    # Original code. Throws IllegalDivisionByZero.
+    #my $current_count_pct = sprintf("%.2f", $current_count*100/$root_count);
 
     #my @kids = split (/\t/, $parent_kid->{$current});
     my @kids = keys %{$parent_kid->{$current}};


### PR DESCRIPTION
output_sunburst_json.abund.pl was failing because root_count was 0 and the variable was being used as a denominator in line 137. I changed it to match the code on line 1394 in output_reports.pl, where if total_depth = 0 , the value of totalAvgDepth_pct is set to zero by default. Does this occur if the dataset is lacking an SSU gene?