### PR TITLE
Fix $DBDIR in rRNAFinder.pl and output_reports.pl

### DIFF
--- a/bin/metaerg.pl
+++ b/bin/metaerg.pl
@@ -212,7 +212,7 @@ msg("Start outputing report files");
 
 
 
-$cmd = "$^X $bin/output_reports.pl -g $datadir/all.gff -o $outdir -f $outdir/$prefix.fna";
+$cmd = "$^X $bin/output_reports.pl -g $datadir/all.gff -o $outdir -f $outdir/$prefix.fna -db $DBDIR";
 
 
 runcmd("$cmd");

--- a/bin/output_reports.pl
+++ b/bin/output_reports.pl
@@ -20,18 +20,19 @@ use Data::Dumper;
 use File::Path qw(make_path remove_tree);
 
 
-my ($gff,$fasta);
+my ($gff,$fasta,$DBDIR);
 my $outdir = ".";
 my $bin = "$FindBin::RealBin";
 my $templatedir = "$bin/../template";
-my $sqlite_dir = "$bin/../db/sqlite3";
 my $EXE = $FindBin::RealScript;
 my $txtdir = "$bin/../txt";
 &GetOptions(
     "g=s" =>\$gff,
     "f=s" =>\$fasta,
-    "o=s" =>\$outdir
+    "o=s" =>\$outdir,
+	"db=s" => \$DBDIR
     );
+my $sqlite3_dir = "$DBDIR/sqlite3";
 
 ($gff && $fasta && $outdir) ||
     die "Name:\n".
@@ -56,7 +57,7 @@ else {
 }
 use DBI;
 my $dbh = DBI->connect(
-    "dbi:SQLite:dbname=$sqlite_dir/metaerg.db",
+    "dbi:SQLite:dbname=$sqlite3_dir/metaerg.db",
     "",
     "",
     { RaiseError => 1 },
@@ -791,7 +792,7 @@ sub output_geneAnnotation{
 sub predict_kegg_pathways{
     
     my ($prefix, $ko2genes, $seqHash) = @_;
-    my $cmd = "MinPath.py -ko $prefix.mapping.txt -report $prefix.minpath -details $prefix.minpath.details > /dev/null 2>&1;";
+    my $cmd = "MinPath1.4.py -ko $prefix.mapping.txt -report $prefix.minpath -details $prefix.minpath.details > /dev/null 2>&1;";
     msg("******start running minpath $cmd\n");
     runcmd("$cmd");
     
@@ -899,7 +900,7 @@ sub predict_metacyc_pathways{
     
 
 
-    my $cmd = "MinPath.py -any $prefix.mapping.txt -map ec2path -report $prefix.minpath -details $prefix.minpath.details > /dev/null 2>&1;";
+    my $cmd = "MinPath1.4.py -any $prefix.mapping.txt -map ec2path -report $prefix.minpath -details $prefix.minpath.details > /dev/null 2>&1;";
     msg("******start running minpath $cmd\n");
     runcmd("$cmd");
     

--- a/bin/output_reports.pl
+++ b/bin/output_reports.pl
@@ -792,7 +792,7 @@ sub output_geneAnnotation{
 sub predict_kegg_pathways{
     
     my ($prefix, $ko2genes, $seqHash) = @_;
-    my $cmd = "MinPath1.4.py -ko $prefix.mapping.txt -report $prefix.minpath -details $prefix.minpath.details > /dev/null 2>&1;";
+    my $cmd = "MinPath.py -ko $prefix.mapping.txt -report $prefix.minpath -details $prefix.minpath.details > /dev/null 2>&1;";
     msg("******start running minpath $cmd\n");
     runcmd("$cmd");
     
@@ -900,7 +900,7 @@ sub predict_metacyc_pathways{
     
 
 
-    my $cmd = "MinPath1.4.py -any $prefix.mapping.txt -map ec2path -report $prefix.minpath -details $prefix.minpath.details > /dev/null 2>&1;";
+    my $cmd = "MinPath.py -any $prefix.mapping.txt -map ec2path -report $prefix.minpath -details $prefix.minpath.details > /dev/null 2>&1;";
     msg("******start running minpath $cmd\n");
     runcmd("$cmd");
     

--- a/bin/rRNAFinder.pl
+++ b/bin/rRNAFinder.pl
@@ -27,7 +27,7 @@ setOptions();
 my $bin = "$FindBin::RealBin";
 $DBDIR ||= "$FindBin::RealBin/../db";
 
-my $rna_hmmdir = "$bin/../db/hmm/rna";
+my $rna_hmmdir = "$DBDIR/hmm/rna";
 if (! -e $outdir) {
     msg("Creating new output folder: $outdir");
     my $cmd = "mkdir -p \Q$outdir\E";


### PR DESCRIPTION
Fix rRNAFinder.pl according to #36 
Fix same issue in `output_reports.pl` by passing $DBDIR to a new argument -db of `output_reports.pl`.
